### PR TITLE
Excerpts: Dynamically create excerpts based on the purpose of the file

### DIFF
--- a/jb-library-import-files.php
+++ b/jb-library-import-files.php
@@ -6,6 +6,18 @@
  */
 class JB_Library_File_Importer {
     /**
+     * The file to be imported
+     * @var string
+     */
+    public string $filepath = '';
+
+    /**
+     * An instance of the JB_PDF_Scraper class
+     * @var JB_PDF_Scraper
+     */
+    public JB_PDF_Scraper $scraper;
+
+    /**
      * The ID of the author to be set for the imported files
      * @var int
      */
@@ -71,9 +83,11 @@ class JB_Library_File_Importer {
      * Constructor to initialize the stock code prefixes
      * @param string $category_slug The category slug to be used for the imported files
      */
-    public function __construct( int $category_id = 0, int $author_id = 0 ) {
+    public function __construct( string $filepath, int $category_id = 0, int $author_id = 0 ) {
+        $this->filepath = $filepath;
+        $this->scraper = new JB_PDF_Scraper( $filepath );
         $this->category_id = $category_id;
-        $this->author_id = $author_id;
+        $this->author_id = ( 0 !== $author_id ) ? $author_id : get_current_user_id();
     }
 
     /**

--- a/jb-library-import-files.php
+++ b/jb-library-import-files.php
@@ -197,7 +197,6 @@ class JB_Library_File_Importer {
 
     /**
      * Get the excerpt content for SDS PDFs
-     * THIS IS WIP UNTIL I FIGURE OUT HOW TO IDENTIFY PRODUCTS IN TDS FILES
      * @return string The excerpt content
      */
     public function get_tds_excerpt_content(): string {
@@ -205,25 +204,32 @@ class JB_Library_File_Importer {
             return '';
         }
 
-        // TODO: Figure out how to identify the product name in TDS files
-        // Extract the Identification section
-        $identification_start = $this->scraper->find_substring_position("identification") + 14; // 14 is the length of the word "identification"
-        $hazard_start = $this->scraper->find_substring_position("hazard");
+        // Extract some text based on the presence of certain keywords
+        $search_terms = array(
+            'features'      => $this->scraper->find_substring_position("features"),
+            'description'   => $this->scraper->find_substring_position("description"),
+            'benefits'      => $this->scraper->find_substring_position("benefits"),
+            'eigenschaften' => $this->scraper->find_substring_position("eigenschaften"),
+            'components'    => $this->scraper->find_substring_position("components"),
+            'information'   => $this->scraper->find_substring_position("information"),
+        );
 
-        // If we can't find either section, return an empty string
-        if ( -1 === $identification_start || -1 === $hazard_start ) {
-            return '';
+        // Remove any terms that were not found (position -1)
+        $positive_positions = array_diff( $search_terms, array( -1 ) );
+
+        if ( empty( $positive_positions ) ) {
+            // If no keywords are found, return a snippet from the start of the document
+            return wp_trim_excerpt( substr( $this->scraper->cleaned_text, 0, 300 ) );
         }
 
-        // Sometimes, things get out of order, so we need to make sure the positions make sense
-        if ( $identification_start > $hazard_start ) {
-            $identification_start = 1;
-        }
-
-        // Figure out how long the "Identification" section is
-        $text_length = $hazard_start - $identification_start;
-
-        $identification_section = substr( $this->scraper->cleaned_text, $identification_start, $text_length );
-        return wp_trim_excerpt( $identification_section );
+        // Get the term with the earliest positive position
+        $best_term = array_search( min( $positive_positions ), $positive_positions );
+        return wp_trim_excerpt(
+            substr(
+                $this->scraper->cleaned_text,
+                ( $search_terms[ $best_term ] + strlen( $best_term ) ), // Offset the start position plus the length of the term
+                300
+            )
+        );
     }
 }   

--- a/jb-library-import-files.php
+++ b/jb-library-import-files.php
@@ -205,6 +205,7 @@ class JB_Library_File_Importer {
             return '';
         }
 
+        // TODO: Figure out how to identify the product name in TDS files
         // Extract the Identification section
         $identification_start = $this->scraper->find_substring_position("identification") + 14; // 14 is the length of the word "identification"
         $hazard_start = $this->scraper->find_substring_position("hazard");

--- a/jb-library-import-files.php
+++ b/jb-library-import-files.php
@@ -36,54 +36,10 @@ class JB_Library_File_Importer {
     public string $tag_slug = '';
 
     /**
-     * The array of stock code prefixes and their corresponding tag slugs
-     * @var array
-     */
-    public array $stock_code_prefix_terms = array(
-        '08' => 'VACUUM BAG SUPPLIES',
-        '09' => 'RESIN EMULSIFIERS',
-        '10' => 'ACETONE',
-        '11' => 'ANVIL SLEEVES',
-        '12' => 'ABRASIVES',
-        '14' => 'RESPERATORS & MASKS',
-        '15' => 'CLOTH / FABRICS',
-        '16' => 'BRUSHES / BUFF SPURS',
-        '17' => 'TOOLING RUBBER',
-        '18' => 'BUFFING PADS',
-        '19' => 'CATALYST',
-        '20' => 'DURATEC PRODUCTS',
-        '21' => 'DISPOSABLE CLOTHING',
-        '22' => 'TOOLING BOARD',
-        '23' => 'ADHESIVES',
-        '24' => 'FILLERS',
-        '25' => 'POLYURETHANE FOAM',
-        '26' => 'MAT',
-        '27' => 'MAT/WOVEN ROVING/ETC',
-        '29' => 'MIXING CUPS',
-        '30' => 'RESINS',
-        '32' => 'RAGS',
-        '34' => 'ALUMINUM TRI HYDRATE',
-        '35' => 'TAPE',
-        '36' => 'ROLLERS',
-        '37' => 'WAXES',
-        '38' => 'SHOP/MFG SUPPLIES/FLM',
-        '39' => 'SOLVENT',
-        '40' => 'GEL COATS',
-        '44' => 'FLUORO PAINTS',
-        '57' => 'FCS FINS SETS',
-        '59' => 'FIN BOXES',
-        '80' => 'EXPOY PRODUCTS',
-        '81' => 'EPOXY PRODUCTS (SYS)',
-        '82' => 'CORE MATERIAL',
-        'CR' => 'COMPOSITE RESOURCES',
-        'XX' => 'EQUIPMENTS',
-    );
-
-    /**
      * Constructor to initialize the stock code prefixes
      * @param string $category_slug The category slug to be used for the imported files
      */
-    public function __construct( string $filepath, int $category_id = 0, int $author_id = 0 ) {
+    public function __construct( string $filepath = '', int $category_id = 0, int $author_id = 0 ) {
         $this->filepath = $filepath;
         $this->scraper = new JB_PDF_Scraper( $filepath );
         $this->category_id = $category_id;
@@ -91,11 +47,18 @@ class JB_Library_File_Importer {
     }
 
     /**
-     * Retrieve the stock code prefixes and their corresponding tag slugs
-     * @return array The array of stock code prefixes and their corresponding tag slugs
+     * Get the tag slug based on the stock code prefix which is the first two characters of the file name
+     * @return string The tag slug
      */
-    public function get_stock_code_prefix_terms(): array {
-        return $this->stock_code_prefix_terms;
+    public function get_tag_slug_based_on_stock_code_prefix(): string {
+        if ( empty( $this->filepath ) ) {
+            return '';
+        }
+
+        $stock_code = substr( $this->file_name, 0, 2 );
+        return isset( JB_LIBRARY_STOCKCODE_PREFIX_TERMS[ $stock_code ] )
+            ? JB_LIBRARY_STOCKCODE_PREFIX_TERMS[ $stock_code ]
+            : '';
     }
 
     /**

--- a/jb-library-import-files.php
+++ b/jb-library-import-files.php
@@ -136,9 +136,6 @@ class JB_Library_File_Importer {
         $attach_data = wp_generate_attachment_metadata( $attachment_id, $file_path );
         wp_update_attachment_metadata( $attachment_id, $attach_data );
 
-        // Scrape the content from the file name
-        // To-do: Implement actual PDF text scraping logic in a separate class
-
         // Get the stock code from the file name
         $stock_code = substr( $file_name, 0, 2 );
         $this->tag_slug = isset( $this->stock_code_prefix_terms[ $stock_code ] ) ? $this->stock_code_prefix_terms[ $stock_code ] : '';
@@ -147,7 +144,8 @@ class JB_Library_File_Importer {
         $doctument_id = wp_insert_post(
             array(
                 'post_title'   => sanitize_file_name( $file_name ),
-                'post_content' => '', // Scraped content can be set here if needed
+                'post_content' => $this->scraper->is_pdf_readable ? $this->scraper->cleaned_text : '',
+                'post_excerpt' => $this->get_document_excerpt(),
                 'post_status'  => 'publish',
                 'post_type'    => 'dlp_document',
                 'post_author'  => $this->author_id,
@@ -171,5 +169,88 @@ class JB_Library_File_Importer {
         }
 
         return $doctument_id;
+    }
+
+
+    /**
+     * Get the excerpt content based on the file category
+     * @return string The excerpt content
+     */
+    public function get_document_excerpt(): string {
+        if ( false === $this->scraper->is_pdf_readable ) {
+            return '';
+        }
+
+        // Determine if the file is an SDS or TDS based on the file name
+        $file_name = basename( $this->filepath );
+        if ( false !== stripos( $file_name, 'SDS' ) ) {
+            return $this->get_sds_excerpt_content();
+        } elseif ( false !== stripos( $file_name, 'TDS' ) ) {
+            return $this->get_tds_excerpt_content();
+        } else {
+            // If we can't determine the type, return a snippet from the start of the document
+            return wp_trim_excerpt( substr( $this->scraper->cleaned_text, 0, 300 ) );
+        }
+    }
+
+    /**
+     * Get the excerpt content for SDS PDFs
+     * @return string The excerpt content
+     */
+    public function get_sds_excerpt_content(): string {
+        if ( false === $this->scraper->is_pdf_readable ) {
+            return '';
+        }
+
+        // Extract the Identification section by searching for the "Identification" and "Hazard" subtitles
+        $identification_start_position = $this->scraper->find_substring_position("identification") + 14; // 14 is the length of the word "identification"
+        $hazard_start_position = $this->scraper->find_substring_position("hazard");
+
+        // If we can't find either subtitle, return an empty string
+        if ( -1 === $identification_start_position || -1 === $hazard_start_position ) {
+            return '';
+        }
+
+        // Sometimes, things get out of order, so we need to make sure the positions make sense
+        if ( $identification_start_position > $hazard_start_position ) {
+            $identification_start_position = 1;
+        }
+
+        // Figure out how long the "Identification" section is
+        $section_text_length = $hazard_start_position - $identification_start_position;
+
+        $identification_section = substr( $this->scraper->cleaned_text, $identification_start_position, $section_text_length );
+        return wp_trim_excerpt( $identification_section );
+    }
+
+    /**
+     * Get the excerpt content for SDS PDFs
+     * THIS IS WIP UNTIL I FIGURE OUT HOW TO IDENTIFY PRODUCTS IN TDS FILES
+     * @return string The excerpt content
+     */
+    public function get_tds_excerpt_content(): string {
+        if ( false === $this->scraper->is_pdf_readable ) {
+            return '';
+        }
+
+        // Extract the Identification section
+        $identification_start = $this->scraper->find_substring_position("identification") + 14; // 14 is the length of the word "identification"
+        $hazard_start = $this->scraper->find_substring_position("hazard");
+
+        // If we can't find either section, return an empty string
+        if ( -1 === $identification_start || -1 === $hazard_start ) {
+            return '';
+        }
+
+        // Sometimes, things get out of order, so we need to make sure the positions make sense
+        if ( $identification_start > $hazard_start ) {
+            $identification_start = 1;
+        }
+
+        // Figure out how long the "Identification" section is
+        $text_length = $hazard_start - $identification_start;
+
+        $identification_section = substr( $cleaned_text, $identification_start, $hazard_start - $identification_start );
+        return wp_trim_excerpt( $identification_section );
     }
 }   

--- a/jb-library-import-files.php
+++ b/jb-library-import-files.php
@@ -9,7 +9,19 @@ class JB_Library_File_Importer {
      * The file to be imported
      * @var string
      */
-    public string $filepath = '';
+    public string $file_path = '';
+
+    /**
+     * The file name without the path
+     * @var string
+     */
+    public string $file_name = '';
+
+    /**
+     * The file type (MIME type)
+     * @var string
+     */
+    public string $file_type = '';
 
     /**
      * An instance of the JB_PDF_Scraper class
@@ -30,7 +42,7 @@ class JB_Library_File_Importer {
     public int $category_id = 0;
 
     /**
-     * The tag slug for the product type based on the stock code
+     * The tag slug according to the prefix of the product stock code (e.g. filename)
      * @var string
      */
     public string $tag_slug = '';
@@ -39,10 +51,16 @@ class JB_Library_File_Importer {
      * Constructor to initialize the stock code prefixes
      * @param string $category_slug The category slug to be used for the imported files
      */
-    public function __construct( string $filepath = '', int $category_id = 0, int $author_id = 0 ) {
-        $this->filepath = $filepath;
-        $this->scraper = new JB_PDF_Scraper( $filepath );
+    public function __construct( string $file_path, int $category_id = 0, int $author_id = 0 ) {
+        // Set file information
+        $this->file_path = $file_path;
+        $this->file_name = sanitize_file_name( basename( $this->file_path ) );
+        $this->file_type = mime_content_type( $file_path );
+        $this->scraper = new JB_PDF_Scraper( $file_path );
+
+        // Fetch and set category and tag information
         $this->category_id = $category_id;
+        $this->tag_slug = $this->get_tag_slug_based_on_stock_code_prefix();
         $this->author_id = ( 0 !== $author_id ) ? $author_id : get_current_user_id();
     }
 
@@ -67,27 +85,23 @@ class JB_Library_File_Importer {
      * @param string $file_path The path to the file to import
      * @return string|WP_Error The DLP_Document post ID on success, or a WP_Error on failure
      */
-    public function import_file( string $file_path ): null|string|WP_Error {
+    public function import_file(): null|string|WP_Error {
         $doctument_id = null;
         
-        if ( ! file_exists( $file_path ) ) {
-            return new WP_Error( "File does not exist: $file_path" );
+        if ( ! file_exists( $this->file_path ) ) {
+            return new WP_Error( "File does not exist: $this->file_path" );
         }
-
-        // Get the file name without the path
-        $file_name = basename( $file_path );
-        $file_type = mime_content_type( $file_path );
 
         // Import the file into the media library
         $attachment_id = wp_insert_attachment(
             array(
-                'guid'           => $file_path,
-                'post_mime_type' => $file_type,
-                'post_title'     => sanitize_file_name( $file_name ),
+                'guid'           => $this->file_path,
+                'post_mime_type' => $this->file_type,
+                'post_title'     => $this->file_name,
                 'post_content'   => '',
                 'post_status'    => 'inherit',
             ),
-            $file_path
+            $this->file_path
         );
 
         if ( is_wp_error( $attachment_id ) ) {
@@ -99,14 +113,10 @@ class JB_Library_File_Importer {
         $attach_data = wp_generate_attachment_metadata( $attachment_id, $file_path );
         wp_update_attachment_metadata( $attachment_id, $attach_data );
 
-        // Get the stock code from the file name
-        $stock_code = substr( $file_name, 0, 2 );
-        $this->tag_slug = isset( $this->stock_code_prefix_terms[ $stock_code ] ) ? $this->stock_code_prefix_terms[ $stock_code ] : '';
-
         // Create a new DLP_Document post
         $doctument_id = wp_insert_post(
             array(
-                'post_title'   => sanitize_file_name( $file_name ),
+                'post_title'   => $this->file_name,
                 'post_content' => $this->scraper->is_pdf_readable ? $this->scraper->cleaned_text : '',
                 'post_excerpt' => $this->get_document_excerpt(),
                 'post_status'  => 'publish',
@@ -116,13 +126,13 @@ class JB_Library_File_Importer {
                     'doc_categories' => $this->category_id ? array( $this->category_id ) : array(),
                     'doc_tags'       => $this->tag_slug ? array( $this->tag_slug ) : array(),
                     'doc_author'     => $this->author_id,
-                    'file_type'      => $file_type,
+                    'file_type'      => $this->file_type,
                 ),
                 'meta_input'   => array(
                     '_dlp_document_link_type' => 'file',
                     '_dlp_attached_file_id'   => $attachment_id,
-                    '_dlp_attached_file_name' => $file_name,
-                    '_dlp_attachment_source'  => $file_path
+                    '_dlp_attached_file_name' => $this->file_name,
+                    '_dlp_attachment_source'  => $this->file_path
                 ),
             )
         );
@@ -145,10 +155,9 @@ class JB_Library_File_Importer {
         }
 
         // Determine if the file is an SDS or TDS based on the file name
-        $file_name = basename( $this->filepath );
-        if ( false !== stripos( $file_name, 'SDS' ) ) {
+        if ( false !== stripos( $this->file_name, 'SDS' ) ) {
             return $this->get_sds_excerpt_content();
-        } elseif ( false !== stripos( $file_name, 'TDS' ) ) {
+        } elseif ( false !== stripos( $this->file_name, 'TDS' ) ) {
             return $this->get_tds_excerpt_content();
         } else {
             // If we can't determine the type, return a snippet from the start of the document
@@ -213,7 +222,7 @@ class JB_Library_File_Importer {
         // Figure out how long the "Identification" section is
         $text_length = $hazard_start - $identification_start;
 
-        $identification_section = substr( $cleaned_text, $identification_start, $hazard_start - $identification_start );
+        $identification_section = substr( $this->scraper->cleaned_text, $identification_start, $text_length );
         return wp_trim_excerpt( $identification_section );
     }
 }   

--- a/jb-library-maintenance.php
+++ b/jb-library-maintenance.php
@@ -17,6 +17,48 @@ defined( 'ABSPATH' ) or die( 'No script kiddies please!' );
 
 define( 'JB_LIBRARY_MAINTENANCE_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 
+define( 'JB_LIBRARY_STOCKCODE_PREFIX_TERMS',
+    array(
+        '08' => 'VACUUM BAG SUPPLIES',
+        '09' => 'RESIN EMULSIFIERS',
+        '10' => 'ACETONE',
+        '11' => 'ANVIL SLEEVES',
+        '12' => 'ABRASIVES',
+        '14' => 'RESPERATORS & MASKS',
+        '15' => 'CLOTH / FABRICS',
+        '16' => 'BRUSHES / BUFF SPURS',
+        '17' => 'TOOLING RUBBER',
+        '18' => 'BUFFING PADS',
+        '19' => 'CATALYST',
+        '20' => 'DURATEC PRODUCTS',
+        '21' => 'DISPOSABLE CLOTHING',
+        '22' => 'TOOLING BOARD',
+        '23' => 'ADHESIVES',
+        '24' => 'FILLERS',
+        '25' => 'POLYURETHANE FOAM',
+        '26' => 'MAT',
+        '27' => 'MAT/WOVEN ROVING/ETC',
+        '29' => 'MIXING CUPS',
+        '30' => 'RESINS',
+        '32' => 'RAGS',
+        '34' => 'ALUMINUM TRI HYDRATE',
+        '35' => 'TAPE',
+        '36' => 'ROLLERS',
+        '37' => 'WAXES',
+        '38' => 'SHOP/MFG SUPPLIES/FLM',
+        '39' => 'SOLVENT',
+        '40' => 'GEL COATS',
+        '44' => 'FLUORO PAINTS',
+        '57' => 'FCS FINS SETS',
+        '59' => 'FIN BOXES',
+        '80' => 'EXPOY PRODUCTS',
+        '81' => 'EPOXY PRODUCTS (SYS)',
+        '82' => 'CORE MATERIAL',
+        'CR' => 'COMPOSITE RESOURCES',
+        'XX' => 'EQUIPMENTS',
+    )
+);
+
 // Include the composer autoloader
 require_once JB_LIBRARY_MAINTENANCE_PLUGIN_DIR . 'vendor/autoload.php';
 

--- a/jb-library-pdf-document-import.php
+++ b/jb-library-pdf-document-import.php
@@ -578,7 +578,109 @@ if ( ! class_exists( 'PDF_Media_Deduplication_Command' ) ) {
             WP_CLI::log( "Percent of files properly parsed: " . ( ( $batch_size - $problem_files ) / $batch_size * 100 ) . "%" );
         }
     }
-    WP_CLI::add_command( 'check-pdf-media-detail', 'check_pdf_media_detail_content' );
+    WP_CLI::add_command( 'check-pdf-media-detail-for-sds', 'check_pdf_media_sds_content' );
+
+    /**
+     * Check that the PDF parser is able to read the content of PDF files in a specified directory.
+     *
+     * Usage:
+     *  wp pdf-media-dedup-delete-logs
+     *
+     * @param array $assoc_args
+     * - Arguments include:
+     *  --subdirectory-path - Subdirectory path for the group of PDFs to be processed
+     *  --batch-size - Number of PDF files to process in each batch (default: 100)
+     * @return void
+     */
+    function check_pdf_media_tds_content( array $args, array $assoc_args = []): void {
+
+        // Set the batch size
+        if ( $assoc_args['batch-size'] && is_numeric( $assoc_args['batch-size'] ) ) {
+            $batch_size = intval( $assoc_args['batch-size'] );
+        } else {
+            $batch_size = 100;
+        }
+        WP_CLI::confirm( "Batch size set to: {$batch_size}. Continue?", 'yes' );
+
+        // Set the directory path
+        $wp_uploads_dir = wp_get_upload_dir();
+        $directory_path = $wp_uploads_dir['basedir'] . '/';
+        if ( isset( $assoc_args['subdirectory-path'] ) && is_string( $assoc_args['subdirectory-path'] ) ) {
+            $directory_path .= rtrim( $assoc_args['subdirectory-path'], '/' ) . '/';
+        }
+        WP_CLI::confirm( "Use directory path: {$directory_path} ?", 'yes' );
+        if ( ! is_dir( $directory_path ) ) {
+            WP_CLI::error( "The specified directory does not exist: {$directory_path}" );
+            return;
+        }
+
+        // Get all PDF files in the directory
+        $pdf_files = glob( $directory_path . '*.pdf' );
+
+        if ( ! empty( $pdf_files ) ) {
+            $problem_files = 0;
+            $unparsed_files = array();
+            $unreadable_text = array();
+            $missing_tds_info = array();
+            $number_of_pdfs = count( $pdf_files );
+
+            $pdf_files_batch = array_slice( $pdf_files, 0, $batch_size, true );
+
+            foreach ( $pdf_files_batch as $file_number => $file ) {
+
+                $scraper = new JB_PDF_Scraper( $file );
+                if ( false === $scraper->is_pdf_readable ) {
+                    WP_CLI::log( "No readable text found in file {$file}." );
+                    WP_CLI::log( "----------------------------------------" );
+                    $unreadable_snippet = substr( $scraper->parsed_text, 0, 200 );
+                    WP_CLI::log( "Parsed text snippet: {$unreadable_snippet}" );
+                    WP_CLI::log( "----------------------------------------" );
+                    $unreadable_text[] = $file;
+                    $problem_files++;
+                    continue;
+                }
+
+                WP_CLI::log( "Details for file {$file} ( {$file_number} of {$batch_size} )" );
+
+                // Handle files where the text could not be scraped
+                if ( empty( $scraper->cleaned_text ) ) {
+                    WP_CLI::log( "No text scraped from file {$file}." );
+                    $problem_files++;
+                    $unparsed_files[] = $file;
+                    continue;
+                }
+
+                $search_terms = array(
+                    'features'      => $scraper->find_substring_position("features"),
+                    'description'   => $scraper->find_substring_position("description"),
+                    'benefits'      => $scraper->find_substring_position("benefits"),
+                    'eigenschaften' => $scraper->find_substring_position("eigenschaften"),
+                    'components'    => $scraper->find_substring_position("components"),
+                    'information'   => $scraper->find_substring_position("information"),
+                );
+
+                if ( -4 === array_sum( $search_terms ) ) {
+                    WP_CLI::confirm( "No FEATURES, DESCRIPTION, or BENEFITS sections found in file {$file}. Continue?", "yes" );
+                    $problem_files++;
+                    $missing_tds_info[] = $file;
+                    continue;
+                }
+
+                $best_term = array_search( max( $search_terms ), $search_terms );
+                WP_CLI::log( "Best term found: {$best_term}" );
+            }
+            WP_CLI::log( "----------------------------------------" );
+
+            WP_CLI::log( "Processed {$batch_size} PDFs of {$number_of_pdfs} PDF files found." );
+            WP_CLI::log( "Unparsed files: " . count( $unparsed_files ) );
+            WP_CLI::log( "Unreadable text files: " . count( $unreadable_text ) );
+            WP_CLI::log( "Missing Identification information in files: " . count( $missing_tds_info ) );
+            WP_CLI::log( "Total problem files: {$problem_files}" );
+            WP_CLI::log( "Total properly parsed files: " . ( $batch_size - $problem_files ) );
+            WP_CLI::log( "Percent of files properly parsed: " . ( ( $batch_size - $problem_files ) / $batch_size * 100 ) . "%" );
+        }
+    }
+    WP_CLI::add_command( 'check-pdf-media-detail-for-tds', 'check_pdf_media_tds_content' );
 
     /**
      * Clear out CSV Log files stored in jb-deduplication/logs related to PDF media deduplication.

--- a/jb-library-pdf-document-import.php
+++ b/jb-library-pdf-document-import.php
@@ -459,7 +459,7 @@ if ( ! class_exists( 'PDF_Media_Deduplication_Command' ) ) {
     WP_CLI::add_command( 'pdf-media-dedup-delete-logs', 'delete_pdf_media_deduplication_log_files' );
 
     /**
-     * Clear out CSV Log files stored in jb-deduplication/logs related to PDF media deduplication.
+     * Check that the PDF parser is able to read the content of PDF files in a specified directory.
      *
      * Usage:
      *  wp pdf-media-dedup-delete-logs
@@ -470,7 +470,7 @@ if ( ! class_exists( 'PDF_Media_Deduplication_Command' ) ) {
      *  --batch-size - Number of PDF files to process in each batch (default: 100)
      * @return void
      */
-    function check_pdf_media_detail_content( array $args, array $assoc_args = []): void {
+    function check_pdf_media_sds_content( array $args, array $assoc_args = []): void {
 
         // Set the batch size
         if ( $assoc_args['batch-size'] && is_numeric( $assoc_args['batch-size'] ) ) {

--- a/jb-library-pdf-document-import.php
+++ b/jb-library-pdf-document-import.php
@@ -473,12 +473,12 @@ if ( ! class_exists( 'PDF_Media_Deduplication_Command' ) ) {
     function check_pdf_media_detail_content( array $args, array $assoc_args = []): void {
 
         // Set the batch size
-        // if ( $assoc_args['batch-size'] && is_numeric( $assoc_args['batch-size'] ) ) {
-        //     $batch_size = intval( $assoc_args['batch-size'] );
-        // } else {
-        //     $batch_size = 100;
-        // }
-        // WP_CLI::confirm( "Batch size set to: {$batch_size}. Continue?", 'yes' );
+        if ( $assoc_args['batch-size'] && is_numeric( $assoc_args['batch-size'] ) ) {
+            $batch_size = intval( $assoc_args['batch-size'] );
+        } else {
+            $batch_size = 100;
+        }
+        WP_CLI::confirm( "Batch size set to: {$batch_size}. Continue?", 'yes' );
 
         // Set the directory path
         $wp_uploads_dir = wp_get_upload_dir();
@@ -499,12 +499,26 @@ if ( ! class_exists( 'PDF_Media_Deduplication_Command' ) ) {
             $problem_files = 0;
             $unparsed_files = array();
             $unreadable_text = array();
+            $missing_sds_info = array();
             $number_of_pdfs = count( $pdf_files );
 
-            foreach ( $pdf_files as $file_number => $file ) {
+            $pdf_files_batch = array_slice( $pdf_files, 0, $batch_size, true );
+
+            foreach ( $pdf_files_batch as $file_number => $file ) {
 
                 $scraper = new JB_PDF_Scraper( $file );
-                WP_CLI::log( "Details for file {$file} ( {$file_number} of {$number_of_pdfs} )" );
+                if ( false === $scraper->is_pdf_readable ) {
+                    WP_CLI::log( "No readable text found in file {$file}." );
+                    WP_CLI::log( "----------------------------------------" );
+                    $unreadable_snippet = substr( $scraper->parsed_text, 0, 200 );
+                    WP_CLI::log( "Parsed text snippet: {$unreadable_snippet}" );
+                    WP_CLI::log( "----------------------------------------" );
+                    $unreadable_text[] = $file;
+                    $problem_files++;
+                    continue;
+                }
+
+                WP_CLI::log( "Details for file {$file} ( {$file_number} of {$batch_size} )" );
                 $scraped_text = $scraper->scrape_pdf_text();
 
                 // Handle files where the text could not be scraped
@@ -530,11 +544,16 @@ if ( ! class_exists( 'PDF_Media_Deduplication_Command' ) ) {
                 if ( $does_identification_exist ) {
                     WP_CLI::log( "IDENTIFICATION section found." );
                 } else {
-                    // Handle files where text was sraped but could not be read
-                    if ( -1 == $identification_start && -1 == $hazard_start ) {
-                        $unreadable_text[] = $file;
-                        WP_CLI::log( "No readable text found in file {$file}." );
+                    // Handle files where the text was scraped but did not contain the sections we were looking for
+                    if (
+                        true === $scraper->is_pdf_readable
+                        && -1 === $identification_start
+                        && -1 === $hazard_start
+                    ) {
+                        WP_CLI::confirm( "No IDENTIFICATION section found in file {$file}. One was expected", "yes" );
+                        $missing_sds_info[] = $file;
                     } else {
+                        // Handle files where text was sraped but could not be read
                         // Throw an error for files where the text was scraped but the sections could not be found
                         WP_CLI::confirm( "IDENTIFICATION section NOT found.
                             Identification position is {$identification_start}.
@@ -544,19 +563,19 @@ if ( ! class_exists( 'PDF_Media_Deduplication_Command' ) ) {
                             "yes"
                         );
                     }
-
                     // Count the number of problem files
                     $problem_files++;
                 }
             }
             WP_CLI::log( "----------------------------------------" );
 
-            WP_CLI::log( "Processed {$number_of_pdfs} files." );
+            WP_CLI::log( "Processed {$batch_size} PDFs of {$number_of_pdfs} PDF files found." );
             WP_CLI::log( "Unparsed files: " . count( $unparsed_files ) );
             WP_CLI::log( "Unreadable text files: " . count( $unreadable_text ) );
+            WP_CLI::log( "Missing Identification information in files: " . count( $missing_sds_info ) );
             WP_CLI::log( "Total problem files: {$problem_files}" );
-            WP_CLI::log( "Total properly parsed files: " . ( $number_of_pdfs - $problem_files ) );
-            WP_CLI::log( "Percent of files properly parsed: " . ( ( $number_of_pdfs - $problem_files ) / $number_of_pdfs * 100 ) . "%" );
+            WP_CLI::log( "Total properly parsed files: " . ( $batch_size - $problem_files ) );
+            WP_CLI::log( "Percent of files properly parsed: " . ( ( $batch_size - $problem_files ) / $batch_size * 100 ) . "%" );
         }
     }
     WP_CLI::add_command( 'check-pdf-media-detail', 'check_pdf_media_detail_content' );

--- a/jb-library-scrape-pdf-documents.php
+++ b/jb-library-scrape-pdf-documents.php
@@ -29,11 +29,19 @@ if ( ! class_exists( 'JB_PDF_Scraper' ) ) {
         public string $cleaned_text = '';
 
         /**
+         * Indicates if the text is readable
+         * @var bool
+         */
+        public bool $is_pdf_readable = false;
+
+        /**
          * Constructor to initialize the file path
          * @param string $file_path The path to the PDF file
          */
         public function __construct( string $file_path = '' ) {
             $this->file_path = $file_path;
+            // This initial check will up the remaining properties
+            $this->check_if_pdf_text_is_readable();
         }
 
         /**
@@ -65,7 +73,7 @@ if ( ! class_exists( 'JB_PDF_Scraper' ) ) {
             if ( ! file_exists( $this->file_path ) ) {
                 return null;
             }
-            $text = '';
+
             $parser = new Parser();
             try {
                 $pdf = $parser->parseFile( $this->file_path );
@@ -83,10 +91,14 @@ if ( ! class_exists( 'JB_PDF_Scraper' ) ) {
          * @return string The cleaned text.
          */
         public function clean_text(): string {
-            $text = $this->parsed_text;
-            if ( empty( $text ) ) {
+            if ( empty( $this->parsed_text ) ) {
                 $this->scrape_pdf_text();
-                $text = $this->parsed_text;
+            }
+
+            $text = $this->parsed_text;
+
+            if ( empty( $text ) ) {
+                return '';
             }
 
             // We aren't sure which type of characters may be causing the issue
@@ -124,6 +136,36 @@ if ( ! class_exists( 'JB_PDF_Scraper' ) ) {
             $lower_substring = strtolower( $substring );
             $position = strpos( $lower_text, $lower_substring );
             return ( $position !== false ) ? $position : -1;
+        }
+
+        /**
+         * Check that the text is readable
+         * @return bool True if readable, false otherwise
+         */
+        public function check_if_pdf_text_is_readable(): bool {
+            //The first time we check, the method may not have been run
+            if ( empty( $this->cleaned_text ) ) {
+                $this->clean_text();
+            }
+
+            //The second time we check, if the cleaned text is still empty, we know it's not readable
+            if ( empty( $this->cleaned_text ) ) {
+                $this->is_pdf_readable = false;
+                return $this->is_pdf_readable;
+            }
+
+            // Use the most common words in the English language as a heuristic
+            $common_words = array( 'the', 'be', 'to', 'of', 'and' );
+            $found_words = 0;
+            foreach ( $common_words as $word ) {
+                if ( $this->find_substring_position( $word ) !== -1 ) {
+                    $found_words++;
+                }
+            }
+
+            // If we found at least 2 common words, we consider the text readable
+            $this->is_pdf_readable = ( $found_words >= 2 ) ? true : false;
+            return $this->is_pdf_readable;
         }
     }
 }

--- a/jb-library-set-import-options.php
+++ b/jb-library-set-import-options.php
@@ -33,11 +33,8 @@ function create_stock_code_doc_tags(): void {
         WP_CLI::error( 'The DLP Document taxonomy "doc_tags" does not exists. New terms cannot be created.' );
     }
 
-    $file_importer = new JB_Library_File_Importer();
-    $stock_code_prefix_terms = $file_importer->get_stock_code_prefix_terms();
-
     WP_CLI::confirm( 'Ready to create the library document tags?', 'yes' );
-    foreach( $stock_code_prefix_terms as $term_slug => $term_name ){
+    foreach( JB_LIBRARY_STOCKCODE_PREFIX_TERMS as $term_slug => $term_name ){
         $new_term = wp_insert_term(
             $term_name,
             'doc_tags',


### PR DESCRIPTION
Purpose of this change:
In order to dynamically populate the `Excerpt` field for the Document Library Pro posts, we want to scrape relevant text from the PDF files, when possible.

Changes Proposed:
Admittedly, this PR is a bit of a mess. There were early design decisions which needed to be amended (like hard coding the Stock Code Prefix terms within the Importer class). These ideally should have been done in a separate PR, but I got ahead of myself.

As for the purpose of this PR, I did a couple of things:
1. Created a boolean check to see if a PDF file is even readable. It doesn't make sense to try and pull an excerpt from a PDF which the script can't read
2. Initialized the PDF scraper class during the construction of the importer class, this way the PDF data is immediately available to  the importer 
3. Identified how I wanted to source the excerpt text from the two different types of PDF files (SDS and TDS). I created a different method for each excerpt type

Testing instructions:
There isn't a clear way to test the importer yet, but you can run the `check-pdf-media-detail-for-sds` and `check-pdf-media-detail-for-tds` commands. It gives a picture of how many files can actually create excerpts.