### PR TITLE
Category ID: Set the ID based on filename contents

### DIFF
--- a/jb-library-import-files.php
+++ b/jb-library-import-files.php
@@ -59,16 +59,16 @@ class JB_Library_File_Importer {
         $this->scraper = new JB_PDF_Scraper( $file_path );
 
         // Fetch and set category and tag information
-        $this->get_category_id_based_on_file_name();
+        $this->set_category_id_based_on_file_name();
         $this->set_tag_slug_based_on_stock_code_prefix();
         $this->author_id = ( 0 !== $author_id ) ? $author_id : get_current_user_id();
     }
 
     /**
      * Get the category ID based on the cagtegory slug contained in the file name
-     * @return void The category ID
+     * @return void Sets the category ID
      */
-    public function get_category_id_based_on_file_name(): void {
+    public function set_category_id_based_on_file_name(): void {
         if ( empty( $this->file_name ) ) {
             $this->file_name = sanitize_file_name( basename( $this->file_path ) );
         }

--- a/jb-library-import-files.php
+++ b/jb-library-import-files.php
@@ -37,7 +37,7 @@ class JB_Library_File_Importer {
 
     /**
      * The category slug for the imported files
-     * @var int
+     * @var int The category ID, if set to 0 no category will be set
      */
     public int $category_id = 0;
 
@@ -51,7 +51,7 @@ class JB_Library_File_Importer {
      * Constructor to initialize the stock code prefixes
      * @param string $category_slug The category slug to be used for the imported files
      */
-    public function __construct( string $file_path, int $category_id = 0, int $author_id = 0 ) {
+    public function __construct( string $file_path, int $author_id = 0 ) {
         // Set file information
         $this->file_path = $file_path;
         $this->file_name = sanitize_file_name( basename( $this->file_path ) );

--- a/jb-library-import-files.php
+++ b/jb-library-import-files.php
@@ -58,7 +58,7 @@ class JB_Library_File_Importer {
         $this->file_type = mime_content_type( $file_path );
         $this->scraper = new JB_PDF_Scraper( $file_path );
 
-        // Fetch and set category and tag information
+        // Set category, tag, and author information
         $this->set_category_id_based_on_file_name();
         $this->set_tag_slug_based_on_stock_code_prefix();
         $this->author_id = ( 0 !== $author_id ) ? $author_id : get_current_user_id();

--- a/jb-library-import-files.php
+++ b/jb-library-import-files.php
@@ -59,9 +59,36 @@ class JB_Library_File_Importer {
         $this->scraper = new JB_PDF_Scraper( $file_path );
 
         // Fetch and set category and tag information
-        $this->category_id = $category_id;
+        $this->get_category_id_based_on_file_name();
         $this->set_tag_slug_based_on_stock_code_prefix();
         $this->author_id = ( 0 !== $author_id ) ? $author_id : get_current_user_id();
+    }
+
+    /**
+     * Get the category ID based on the cagtegory slug contained in the file name
+     * @return void The category ID
+     */
+    public function get_category_id_based_on_file_name(): void {
+        if ( empty( $this->file_name ) ) {
+            $this->file_name = sanitize_file_name( basename( $this->file_path ) );
+        }
+
+        // Set the term slug based on the file name
+        if ( false !== stripos( $this->file_name, 'SDS' ) ) {
+            $term_slug = 'safety-data-sheets';
+        } elseif ( false !== stripos( $this->file_name, 'TDS' ) ) {
+            $term_slug = 'technical-data-sheets';
+        } else {
+            // If we can't determine the type, return early
+            return;
+        }
+
+        // Get the term by slug and set the category ID
+        $term = get_term_by( 'slug', $term_slug, 'doc_categories', OBJECT );
+        if ( $term ) {
+            $this->category_id = $term->term_id;
+        }
+        return;
     }
 
     /**


### PR DESCRIPTION
Problem:

The document library is intentionally designed to make use of only two `doc_categories` terms; `safety-data-sheets` and `technical-data-sheets`. The files which are being imported into the document library specify the category which they belong to by using the strings `SDS` and `TDS` within their filenames.

When a file is imported into the document library, the goal is to continue to use this binary categorization for each file.

Proposed Changes:
This PR not only introduces the `set_category_id_based_on_file_name()` method, but it also removes the ability for a user to pass a category ID into the `JB_Library_File_Importer` constructor. This way, the user cannot unintentionally create a new category or try to assign one outside of the intended categorization schema.

It should be noted that if the strings denoting the category are not present in the file name, no category will be assigned to the `dlp_document` post which is created. Since this is a custom post type with a custom taxonomy, the post can exist without a category assigned.