### PR TITLE
Tag. Slug: Avoid passing strings back by setting property in method

### DIFF
--- a/jb-library-import-files.php
+++ b/jb-library-import-files.php
@@ -60,7 +60,7 @@ class JB_Library_File_Importer {
 
         // Fetch and set category and tag information
         $this->category_id = $category_id;
-        $this->get_tag_slug_based_on_stock_code_prefix();
+        $this->set_tag_slug_based_on_stock_code_prefix();
         $this->author_id = ( 0 !== $author_id ) ? $author_id : get_current_user_id();
     }
 
@@ -68,7 +68,7 @@ class JB_Library_File_Importer {
      * Get the tag slug based on the stock code prefix which is the first two characters of the file name
      * @return void Sets the tag slug
      */
-    public function get_tag_slug_based_on_stock_code_prefix(): void {
+    public function set_tag_slug_based_on_stock_code_prefix(): void {
         if ( empty( $this->filepath ) ) {
             return;
         }

--- a/jb-library-import-files.php
+++ b/jb-library-import-files.php
@@ -60,23 +60,24 @@ class JB_Library_File_Importer {
 
         // Fetch and set category and tag information
         $this->category_id = $category_id;
-        $this->tag_slug = $this->get_tag_slug_based_on_stock_code_prefix();
+        $this->get_tag_slug_based_on_stock_code_prefix();
         $this->author_id = ( 0 !== $author_id ) ? $author_id : get_current_user_id();
     }
 
     /**
      * Get the tag slug based on the stock code prefix which is the first two characters of the file name
-     * @return string The tag slug
+     * @return void Sets the tag slug
      */
-    public function get_tag_slug_based_on_stock_code_prefix(): string {
+    public function get_tag_slug_based_on_stock_code_prefix(): void {
         if ( empty( $this->filepath ) ) {
-            return '';
+            return;
         }
 
         $stock_code = substr( $this->file_name, 0, 2 );
-        return isset( JB_LIBRARY_STOCKCODE_PREFIX_TERMS[ $stock_code ] )
+        $this->tag_slug = isset( JB_LIBRARY_STOCKCODE_PREFIX_TERMS[ $stock_code ] )
             ? JB_LIBRARY_STOCKCODE_PREFIX_TERMS[ $stock_code ]
             : '';
+        return;
     }
 
     /**


### PR DESCRIPTION
Proposed Changes:
Simplify setting the `tag_slug` property by setting it within the `set_tag_slug_based_on_stock_code_prefix` method rather than returning the string. Rename the method to be a "setter" rather than a "getter".