### PR TITLE
Document Taxonomy: Use more reliable method for inserting post terms

### DIFF
--- a/jb-library-import-files.php
+++ b/jb-library-import-files.php
@@ -98,7 +98,7 @@ class JB_Library_File_Importer {
     public function set_tag_slug_based_on_stock_code_prefix(): void {
         $stock_code = substr( $this->file_name, 0, 2 );
         $this->tag_slug = isset( JB_LIBRARY_STOCKCODE_PREFIX_TERMS[ $stock_code ] )
-            ? JB_LIBRARY_STOCKCODE_PREFIX_TERMS[ $stock_code ]
+            ? $stock_code
             : '';
         return;
     }

--- a/jb-library-import-files.php
+++ b/jb-library-import-files.php
@@ -146,12 +146,6 @@ class JB_Library_File_Importer {
                 'post_status'  => 'publish',
                 'post_type'    => 'dlp_document',
                 'post_author'  => $this->author_id,
-                'tax_input'    => array(
-                    'doc_categories' => $this->category_id ? array( $this->category_id ) : array(),
-                    'doc_tags'       => $this->tag_slug ? array( $this->tag_slug ) : array(),
-                    'doc_author'     => $this->author_id,
-                    'file_type'      => $this->file_type,
-                ),
                 'meta_input'   => array(
                     '_dlp_document_link_type' => 'file',
                     '_dlp_attached_file_id'   => $attachment_id,
@@ -160,6 +154,12 @@ class JB_Library_File_Importer {
                 ),
             )
         );
+
+        // Set the document taxonomies if one was determined
+        wp_set_object_terms( $doctument_id, $this->category_id, 'doc_categories', false );
+        wp_set_object_terms( $doctument_id, $this->tag_slug, 'doc_tags', false );
+        wp_set_object_terms( $doctument_id, $this->file_type, 'file_type', false );
+        wp_set_object_terms( $doctument_id, $this->author_id, 'doc_author', false );
    
         if ( is_wp_error( $doctument_id ) ) {
             return new WP_Error( "Failed to create DLP_Document post: " . $doctument_id->get_error_message() );

--- a/jb-library-import-files.php
+++ b/jb-library-import-files.php
@@ -155,15 +155,15 @@ class JB_Library_File_Importer {
             )
         );
 
+        if ( is_wp_error( $doctument_id ) ) {
+            return new WP_Error( "Failed to create DLP_Document post: " . $doctument_id->get_error_message() );
+        }
+
         // Set the document taxonomies if one was determined
         wp_set_object_terms( $doctument_id, $this->category_id, 'doc_categories', false );
         wp_set_object_terms( $doctument_id, $this->tag_slug, 'doc_tags', false );
         wp_set_object_terms( $doctument_id, $this->file_type, 'file_type', false );
         wp_set_object_terms( $doctument_id, $this->author_id, 'doc_author', false );
-   
-        if ( is_wp_error( $doctument_id ) ) {
-            return new WP_Error( "Failed to create DLP_Document post: " . $doctument_id->get_error_message() );
-        }
 
         return $doctument_id;
     }


### PR DESCRIPTION
## Problem:
When running the PDF import, none of the taxonomy terms are being set.

The `JB_Library_File_Importer` class uses the post arguments within `wp_insert_post` to set the taxonomy terms. However, these can only be set based on the permissions of the user. Since we are creating these posts outside of the scope of a user, the tags are not being set when the script is being run.

## Solution
This PR removes the reliance on the `tax_input` within the arguments passed to `wp_insert_post`. Instead, it waits for the post to be created and then calls `wp_set_object_terms` for each of the four taxonomies.