### PR TITLE
Clean Sweep: Avoid fatal by using global var for table prefix

### DIFF
--- a/jb-library-pdf-clean-sweep.php
+++ b/jb-library-pdf-clean-sweep.php
@@ -274,7 +274,7 @@ if ( ! class_exists( 'PDF_Media_Deletion_Commandq' ) ) {
             global $wpdb;
             $wpdb->query(
                 "
-                UPDATE wp_term_taxonomy tt
+                UPDATE $wpdb->term_taxonomy tt
                 SET count = (SELECT count(p.ID)
                 FROM wp_term_relationships tr
                 LEFT JOIN wp_posts p ON p.ID = tr.object_id


### PR DESCRIPTION
As @billrobbins pointed out in https://github.com/JessBoctor/jb-library-maintenance/issues/7:

> Nitpick: Swapping out the hard-coded table names for $wpdb properties would accommodate different table prefixes and make it consistent with other table references.

This ran into a fatal the first time I tried the clean sweep command in production. Replaced the `wp_` prefix with `$wpdb` global.