### PR TITLE
Add optional PDF text fallback hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ wp-config.php
 # Log files
 *.log
 /wp-content/plugins/jb-library-maintenance/logs/
+*.local.php
+*.parsed.json
 
 # htaccess
 /.htaccess

--- a/README.md
+++ b/README.md
@@ -60,3 +60,58 @@ A log of files that failed to import should be printed. If you aren’t sure if 
 `wp check-pdf-import-status`
 
 It will print any files which do not have corresponding `dlp_document` or `attachment` posts.
+
+## Optional PDF text fallback hook
+The PDF scraper first tries to read PDF text with the bundled PHP PDF parser. Some SDS files do not parse cleanly with that parser, so the scraper includes an optional hook for a local fallback parser:
+
+`jb_library_pdf_scraper_fallback_text`
+
+This hook is intended for local maintenance runs only. It lets a developer provide PDF text from a machine-specific tool without committing that tool path or shell command to the repository.
+
+### Safety gates
+The fallback hook will only run when both of these are true:
+
+- The plugin is running under WP-CLI.
+- `JB_LIBRARY_ENABLE_PDF_TEXT_FALLBACK` is set to `true`.
+
+This prevents the fallback from running during normal web requests on a webhost. The local fallback file is also ignored by git.
+
+### Local setup
+Create this file locally:
+
+`wp-content/plugins/jb-library-maintenance/jb-library-pdf-fallback-parser.local.php`
+
+Enable the fallback for your local WP-CLI run by defining this before the plugin loads, usually in local `wp-config.php`:
+
+```php
+define( 'JB_LIBRARY_ENABLE_PDF_TEXT_FALLBACK', true );
+```
+
+Then register a callback:
+
+```php
+<?php
+if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+    return;
+}
+
+if ( ! defined( 'JB_LIBRARY_ENABLE_PDF_TEXT_FALLBACK' ) || ! JB_LIBRARY_ENABLE_PDF_TEXT_FALLBACK ) {
+    return;
+}
+
+add_filter(
+    'jb_library_pdf_scraper_fallback_text',
+    function ( $fallback_text, string $file_path ) {
+        if ( is_string( $fallback_text ) && trim( $fallback_text ) !== '' ) {
+            return $fallback_text;
+        }
+
+        // Run your local parser here and return extracted text.
+        return null;
+    },
+    10,
+    2
+);
+```
+
+Do not commit `*.local.php` files or generated `*.parsed.json` files. They are local cache/integration files only.

--- a/jb-library-scrape-pdf-documents.php
+++ b/jb-library-scrape-pdf-documents.php
@@ -1,11 +1,20 @@
 <?php
 /**
  * When dealing with thousands of files, we need a way to scrape the PDF text programmatically
- * 
- * The goal here is to create a CLI Command that will pull the file name 
+ *
+ * The goal here is to create a CLI Command that will pull the file name
  */
 
 use Smalot\PdfParser\Parser;
+
+if ( ! defined( 'JB_LIBRARY_ENABLE_PDF_TEXT_FALLBACK' ) ) {
+    define( 'JB_LIBRARY_ENABLE_PDF_TEXT_FALLBACK', false );
+}
+
+$local_fallback_parser = __DIR__ . '/jb-library-pdf-fallback-parser.local.php';
+if ( defined( 'WP_CLI' ) && WP_CLI && JB_LIBRARY_ENABLE_PDF_TEXT_FALLBACK && file_exists( $local_fallback_parser ) ) {
+    require_once $local_fallback_parser;
+}
 
 if ( ! class_exists( 'JB_PDF_Scraper' ) ) {
     class JB_PDF_Scraper {
@@ -22,7 +31,7 @@ if ( ! class_exists( 'JB_PDF_Scraper' ) ) {
          */
         public string $parsed_text = '';
 
-        /** 
+        /**
          * The cleaned text content from the PDF
          * @var string
          */
@@ -40,14 +49,42 @@ if ( ! class_exists( 'JB_PDF_Scraper' ) ) {
          */
         public function __construct( string $file_path = '' ) {
             $this->file_path = $file_path;
-            // This initial check will up the remaining properties
+            $this->load_parsed_text_from_cache();
+
+            // This initial check will set up the remaining properties.
             $this->check_if_pdf_text_is_readable();
         }
 
         /**
-         * Scrape text content from a PDF file.
+         * Try to load parsed text from a companion JSON file produced by the external scraper.
          *
-         * @return array|null Extracted text or null on failure.
+         * @return void
+         */
+        private function load_parsed_text_from_cache(): void {
+            if ( empty( $this->file_path ) ) {
+                return;
+            }
+
+            $cache_file = $this->file_path . '.parsed.json';
+            if ( ! file_exists( $cache_file ) ) {
+                return;
+            }
+
+            $contents = file_get_contents( $cache_file );
+            if ( false === $contents ) {
+                return;
+            }
+
+            $data = json_decode( $contents, true );
+            if ( is_array( $data ) && isset( $data['text'] ) && null !== $data['text'] ) {
+                $this->parsed_text = (string) $data['text'];
+            }
+        }
+
+        /**
+         * Scrape PDF metadata/details.
+         *
+         * @return array|null Extracted details or null on failure.
          */
         public function scrape_pdf_details() {
             if ( ! file_exists( $this->file_path ) ) {
@@ -59,7 +96,6 @@ if ( ! class_exists( 'JB_PDF_Scraper' ) ) {
                 $pdf = $parser->parseFile( $this->file_path );
                 return $pdf->getDetails();
             } catch ( Exception $e ) {
-                // Handle error or log it
                 return null;
             }
         }
@@ -77,17 +113,49 @@ if ( ! class_exists( 'JB_PDF_Scraper' ) ) {
             $parser = new Parser();
             try {
                 $pdf = $parser->parseFile( $this->file_path );
-                $this->parsed_text = $pdf->getText();
-                return $this->parsed_text;
+                $text = method_exists( $pdf, 'getText' ) ? $pdf->getText() : (string) $pdf;
+                if ( is_string( $text ) && trim( $text ) !== '' ) {
+                    $this->parsed_text = $text;
+                    return $this->parsed_text;
+                }
             } catch ( Exception $e ) {
-                // Handle error or log it
+                // Fall through to the optional fallback below.
+            }
+
+            $fallback_text = $this->run_pdf_text_fallback();
+            if ( is_string( $fallback_text ) && trim( $fallback_text ) !== '' ) {
+                $this->parsed_text = $fallback_text;
+                return $this->parsed_text;
+            }
+
+            return null;
+        }
+
+        /**
+         * Run an optional fallback parser for the current PDF.
+         *
+         * @return string|null Extracted text or null on failure.
+         */
+        private function run_pdf_text_fallback(): ?string {
+            if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
                 return null;
             }
+
+            if ( ! JB_LIBRARY_ENABLE_PDF_TEXT_FALLBACK ) {
+                return null;
+            }
+
+            if ( ! function_exists( 'apply_filters' ) ) {
+                return null;
+            }
+
+            $fallback_text = apply_filters( 'jb_library_pdf_scraper_fallback_text', null, $this->file_path, $this );
+            return is_string( $fallback_text ) ? $fallback_text : null;
         }
 
         /**
          * Clean up text by removing unwanted characters.
-         * 
+         *
          * @return string The cleaned text.
          */
         public function clean_text(): string {
@@ -101,19 +169,15 @@ if ( ! class_exists( 'JB_PDF_Scraper' ) ) {
                 return '';
             }
 
-            // We aren't sure which type of characters may be causing the issue
-            // So we will try multiple preg_replace based on unicode types
-            // UTF-8
-            $cleaned_text = preg_replace( '/[^\x0A\x20-\x7E]/',' ', $text );
+            // We aren't sure which type of characters may be causing the issue, so try multiple patterns.
+            $cleaned_text = preg_replace( '/[^\x0A\x20-\x7E]/', ' ', $text );
 
-            // 8 bit extended ASCII
             if ( empty( $cleaned_text ) ) {
-                $cleaned_text = preg_replace('/[\x00-\x1F\x7F]/', ' ', $text);
+                $cleaned_text = preg_replace( '/[\x00-\x1F\x7F]/', ' ', $text );
             }
 
-            // 7 bit ASCII
             if ( empty( $cleaned_text ) ) {
-                $cleaned_text = preg_replace('/[\x00-\x1F\x7F-\xFF]/', ' ', $text );
+                $cleaned_text = preg_replace( '/[\x00-\x1F\x7F-\xFF]/', ' ', $text );
             }
 
             $this->cleaned_text = $cleaned_text;
@@ -135,17 +199,7 @@ if ( ! class_exists( 'JB_PDF_Scraper' ) ) {
             $lower_text = strtolower( $this->cleaned_text );
             $lower_substring = strtolower( $substring );
             $position = strpos( $lower_text, $lower_substring );
-            return ( $position !== false ) ? $position : -1;
-        }
-
-        /**
-         * Normalize whitespace for transport extraction values.
-         *
-         * @param string $text
-         * @return string
-         */
-        private function normalize_whitespace( string $text ): string {
-            return trim( preg_replace( '/\s+/', ' ', $text ) );
+            return ( false !== $position ) ? $position : -1;
         }
 
         /**
@@ -160,205 +214,20 @@ if ( ! class_exists( 'JB_PDF_Scraper' ) ) {
         }
 
         /**
-         * Extract a value from the cleaned text using an ordered list of labels.
+         * Check that the text is readable.
          *
-         * @param array $labels
-         * @param int   $max_length
-         * @return string
-         */
-        private function extract_label_value( array $labels, int $max_length = 160 ): string {
-            $this->ensure_clean_text();
-            $text = $this->cleaned_text;
-
-            foreach ( $labels as $label ) {
-                $pattern = '/\b' . preg_quote( $label, '/' ) . '\b\s*[:\-]?\s*(.+?)(?=\r?\n|$)/is';
-                if ( preg_match( $pattern, $text, $matches ) ) {
-                    return $this->normalize_whitespace( substr( $matches[1], 0, $max_length ) );
-                }
-            }
-
-            return '';
-        }
-
-        /**
-         * Extract the first regex capture group from the cleaned text.
-         *
-         * @param string $pattern
-         * @return string
-         */
-        private function extract_regex_value( string $pattern ): string {
-            $this->ensure_clean_text();
-
-            if ( preg_match( $pattern, $this->cleaned_text, $matches ) ) {
-                return trim( $matches[1] );
-            }
-
-            return '';
-        }
-
-        /**
-         * Get the UN number for this SDS.
-         *
-         * @return string
-         */
-        public function get_un_code(): string {
-            $un_number = $this->extract_regex_value( '/\bUN[ \-]*([0-9]{4})\b/i' );
-            return $un_number ? 'UN' . $un_number : '';
-        }
-
-        /**
-         * Get the hazardous description / proper shipping name for this SDS.
-         *
-         * @return string
-         */
-        public function get_hazardous_description(): string {
-            return $this->extract_label_value(
-                array(
-                    'proper shipping name',
-                    'hazardous description',
-                    'hazard description',
-                    'description of hazard',
-                    'shipping name',
-                    'technical name',
-                ),
-                200
-            );
-        }
-
-        /**
-         * Get the hazardous class number from this SDS.
-         *
-         * @return string
-         */
-        public function get_hazardous_class_number(): string {
-            return $this->extract_regex_value(
-                '/\b(?:hazard\s*(?:class|group)|hazardous\s*group|hazardous\s*class)\b[^0-9A-Za-z]*(\d+(?:\.\d+)?)/i'
-            );
-        }
-
-        /**
-         * Get the packing group for this SDS.
-         *
-         * @return string
-         */
-        public function get_packing_group(): string {
-            return strtoupper( $this->extract_regex_value(
-                '/\b(?:packing\s*group|pg\b)\b[^A-Z0-9]*(I{1,3}|II|III|1|2|3)\b/i'
-            ) );
-        }
-
-        /**
-         * Get the shipping class for this SDS.
-         *
-         * @return string
-         */
-        public function get_shipping_class(): string {
-            return strtoupper( $this->extract_regex_value(
-                '/\b(?:shipping\s*group|shipping\s*class|ship\s*group|ship\s*class|shp\s*group|shp\s*class)\b[^A-Z0-9]*(I{1,3}|II|III|1|2|3)\b/i'
-            ) );
-        }
-
-        /**
-         * Get the NMFC code for this SDS.
-         *
-         * @return string
-         */
-        public function get_nmfc_code(): string {
-            return $this->extract_regex_value('/\bNMFC\b[^0-9]*(\d{4,6})\b/i');
-        }
-
-        /**
-         * Get the transport section text for this SDS.
-         *
-         * @param int $max_length
-         * @return string
-         */
-        public function get_transport_section( int $max_length = 1200 ): string {
-            $this->ensure_clean_text();
-            $text = $this->cleaned_text;
-
-            $start_labels = array(
-                'transport information',
-                'transport details',
-                'transportation information',
-                'transportation details',
-                'transportation',
-                'transport',
-            );
-
-            $start_position = false;
-            foreach ( $start_labels as $label ) {
-                $pattern = '/\b' . preg_quote( $label, '/' ) . '\b/i';
-                if ( preg_match( $pattern, $text, $matches, PREG_OFFSET_CAPTURE ) ) {
-                    $start_position = $matches[0][1];
-                    break;
-                }
-            }
-
-            if ( false === $start_position ) {
-                return '';
-            }
-
-            $end_pattern = '/\n\s*(?:section\s*\d+\b|regulatory information|regulatory|exposure controls|handling|storage|stability|ecological|disposal|hazard|identification|composition|first aid|fire fighting|accidental release|physical and chemical properties|other information|other hazards)\b/i';
-            $end_position = false;
-
-            if ( preg_match( $end_pattern, $text, $end_matches, PREG_OFFSET_CAPTURE, $start_position + 1 ) ) {
-                $end_position = $end_matches[0][1];
-            }
-
-            $section_text = $end_position !== false
-                ? substr( $text, $start_position, min( $max_length, $end_position - $start_position ) )
-                : substr( $text, $start_position, $max_length );
-
-            return $this->normalize_whitespace( $section_text );
-        }
-
-        /**
-         * Return the transport-related SDS details.
-         *
-         * @return array
-         */
-        public function get_sds_transport_details(): array {
-            if ( false === $this->is_pdf_readable ) {
-                return array(
-                    'un_code'                  => '',
-                    'hazardous_description'    => '',
-                    'hazardous_class_number'   => '',
-                    'packing_group'            => '',
-                    'shipping_class'           => '',
-                    'nmfc_code'                => '',
-                    'transport_section'        => '',
-                );
-            }
-
-            return array(
-                'un_code'                => $this->get_un_code(),
-                'hazardous_description'  => $this->get_hazardous_description(),
-                'hazardous_class_number' => $this->get_hazardous_class_number(),
-                'packing_group'          => $this->get_packing_group(),
-                'shipping_class'         => $this->get_shipping_class(),
-                'nmfc_code'              => $this->get_nmfc_code(),
-                'transport_section'      => $this->get_transport_section(),
-            );
-        }
-
-        /**
-         * Check that the text is readable
-         * @return bool True if readable, false otherwise
+         * @return bool True if readable, false otherwise.
          */
         public function check_if_pdf_text_is_readable(): bool {
-            //The first time we check, the method may not have been run
             if ( empty( $this->cleaned_text ) ) {
                 $this->clean_text();
             }
 
-            //The second time we check, if the cleaned text is still empty, we know it's not readable
             if ( empty( $this->cleaned_text ) ) {
                 $this->is_pdf_readable = false;
                 return $this->is_pdf_readable;
             }
 
-            // Use the most common words in the English language as a heuristic
             $common_words = array( 'the', 'be', 'to', 'of', 'and' );
             $found_words = 0;
             foreach ( $common_words as $word ) {
@@ -367,8 +236,7 @@ if ( ! class_exists( 'JB_PDF_Scraper' ) ) {
                 }
             }
 
-            // If we found at least 2 common words, we consider the text readable
-            $this->is_pdf_readable = ( $found_words >= 2 ) ? true : false;
+            $this->is_pdf_readable = ( $found_words >= 2 );
             return $this->is_pdf_readable;
         }
     }


### PR DESCRIPTION
Not all PDFs can be parsed by the smalot/pdfparser component. However, more robust parsers require installation of specific libraries which may not be available on a web host server. If this plugin is installed in a local installation, this hook allows the user to use additional pdf parser libraries on a local installation of this plugin to do more robust parsing.