### PR TITLE
Chore/ignore transport logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ wp-config.php
 
 # Log files
 *.log
-/wp-content/plugins/jb-library-maintenance/logs/
+/logs/
 *.local.php
 *.parsed.json
 


### PR DESCRIPTION
This change prevents logs from being added to the repo by correcting the .gitignore file.